### PR TITLE
Style and size content area

### DIFF
--- a/DefaultJournalsUcThemePlugin.inc.php
+++ b/DefaultJournalsUcThemePlugin.inc.php
@@ -36,6 +36,12 @@ class DefaultJournalsUcThemePlugin extends ThemePlugin {
 			$this->removeOption('typography');
 		}
 
+		$this->addOption('proceedingsArray', 'FieldText', [
+			'label' => __('plugins.themes.defaultJournalsUc.option.proceedingsArray.label'),
+			'description' => __('plugins.themes.defaultJournalsUc.option.proceedingsArray.description'),
+			'default' => ''
+		]);
+
 		// Load the Montserrat and Open Sans fonts
 		$this->addStyle(
 			'font',
@@ -63,7 +69,21 @@ class DefaultJournalsUcThemePlugin extends ThemePlugin {
 		// ignore those added by the parent theme. This gets rid of @font
 		// variable overrides from the typography option
 		$additionalLessVariables = array();
+
+
+    $proceedings = $this->getOption('proceedingsArray');
+    HookRegistry::register ('TemplateManager::display', array($this, 'loadTemplateData'));
+
   }
+  	public function loadTemplateData($hookName, $args) {
+			// Retrieve the TemplateManager and the template filename
+			$templateMgr = $args[0];
+			$template = $args[1];
+			// Don't do anything if we're not loading the right template
+      $proceedingsArray = explode(",", $this->getOption('proceedingsArray'));
+  		$templateMgr->assign('proceedings', $proceedingsArray);
+		}
+
 
 	/**
 	 * Get the display name of this plugin

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -16,3 +16,9 @@ msgstr "Journals@UC Homepage Theme"
 
 msgid "plugins.themes.defaultJournalsUc.description"
 msgstr "A custom homepage theme for Journals@UC."
+
+msgid "plugins.themes.defaultJournalsUc.option.proceedingsArray.label"
+msgstr "Proceedings Column"
+
+msgid "plugins.themes.defaultJournalsUc.option.proceedingsArray.description"
+msgstr "Add comma delimited journal IDs to populate the proceedings column on the home page."

--- a/styles/index.less
+++ b/styles/index.less
@@ -19,3 +19,4 @@
  // @import "components.less";
 
  @import "head.less";
+ @import "indexSite.less";

--- a/styles/indexSite.less
+++ b/styles/indexSite.less
@@ -1,0 +1,59 @@
+.red-hr {
+  margin-top: 50px;
+  border-top: 5px solid @primary;
+}
+
+h1 {
+  color: @primary;
+}
+
+.col {
+  float: left;
+  width: 50%;
+  padding-left: 20px;
+}
+
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.pkp_page_index .journals .thumb {
+  padding-right: 20px;
+  padding-top: 15px;
+}
+
+@media (max-width: 600px) {
+  .col {
+		float: unset;
+    width: 100%;
+		padding-left: unset;
+  }
+
+  .row:after {
+		display: unset;
+		clear: unset;
+  }
+}
+
+@media (min-width: 992px) {
+	.pkp_structure_main {
+			width: 900px !important;
+	}
+}
+
+@media (min-width: 1200px) {
+	.pkp_structure_main {
+			width: 1100px !important;
+	}
+}
+
+
+
+
+
+.pkp_page_index .journals>ul>li {
+  border-top: none !important;
+}

--- a/templates/frontend/pages/indexSite.tpl
+++ b/templates/frontend/pages/indexSite.tpl
@@ -1,0 +1,132 @@
+{**
+ * templates/frontend/pages/indexSite.tpl
+ *
+ * Copyright (c) 2014-2020 Simon Fraser University
+ * Copyright (c) 2003-2020 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * Site index.
+ *
+ *}
+{include file="frontend/components/header.tpl"}
+{assign var=journalsArray value=$journals->toArray()}
+
+<div class="page_index_site row">
+
+	{if $about}
+		<div class="about_site">
+			{$about|nl2br}
+		</div>
+	{/if}
+<hr class="red-hr">
+	<div class="journals col">
+		<h1>
+      Journals
+		</h1>
+		{if $journals->wasEmpty()}
+			{translate key="site.noJournals"}
+		{else}
+			<ul>
+				{foreach from=$journalsArray item=journal}
+					{assign var="id" value=$journal->getId()}
+          {if ! $id|in_array:$proceedings}
+					{capture assign="url"}{url journal=$journal->getPath()}{/capture}
+					{assign var="thumb" value=$journal->getLocalizedData('journalThumbnail')}
+					{assign var="description" value=$journal->getLocalizedDescription()}
+					<li{if $thumb} class="has_thumb"{/if}>
+						{if $thumb}
+							<div class="thumb">
+								<a href="{$url|escape}">
+									<img src="{$journalFilesPath}{$journal->getId()}/{$thumb.uploadName|escape:"url"}"{if $thumb.altText} alt="{$thumb.altText|escape|default:''}"{/if}>
+								</a>
+							</div>
+						{/if}
+
+						<div class="body">
+							<h3>
+								<a href="{$url|escape}" rel="bookmark">
+									{$journal->getLocalizedName()}
+								</a>
+							</h3>
+							{if $description}
+								<div class="description">
+									{$description|nl2br|truncate:450}
+								</div>
+							{/if}
+							<ul class="links">
+								<li class="view">
+									<a href="{$url|escape}">
+										{translate key="site.journalView"}
+									</a>
+								</li>
+								<li class="current">
+									<a href="{url|escape journal=$journal->getPath() page="issue" op="current"}">
+										{translate key="site.journalCurrent"}
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+          {/if}
+				{/foreach}
+			</ul>
+		{/if}
+	</div>
+
+
+	<div class="journals col">
+		<h1>
+       Proceedings
+		</h1>
+		{if $journals->wasEmpty()}
+			{translate key="site.noJournals"}
+		{else}
+			<ul>
+				{foreach from=$journalsArray item=journal}
+					{assign var="id" value=$journal->getId()}
+          {if $id|in_array:$proceedings}
+					{capture assign="url"}{url journal=$journal->getPath()}{/capture}
+					{assign var="thumb" value=$journal->getLocalizedData('journalThumbnail')}
+					{assign var="description" value=$journal->getLocalizedDescription()}
+					<li{if $thumb} class="has_thumb"{/if}>
+						{if $thumb}
+							<div class="thumb">
+								<a href="{$url|escape}">
+									<img src="{$journalFilesPath}{$journal->getId()}/{$thumb.uploadName|escape:"url"}"{if $thumb.altText} alt="{$thumb.altText|escape|default:''}"{/if}>
+								</a>
+							</div>
+						{/if}
+						<div class="body">
+							<h3>
+								<a href="{$url|escape}" rel="bookmark">
+									{$journal->getLocalizedName()}
+								</a>
+							</h3>
+							{if $description}
+								<div class="description">
+									{$description|nl2br|truncate:450}
+								</div>
+							{/if}
+							<ul class="links">
+								<li class="view">
+									<a href="{$url|escape}">
+										{translate key="site.journalView"}
+									</a>
+								</li>
+								<li class="current">
+									<a href="{url|escape journal=$journal->getPath() page="issue" op="current"}">
+										{translate key="site.journalCurrent"}
+									</a>
+								</li>
+							</ul>
+						</div>
+					</li>
+				{/if}
+				{/foreach}
+			</ul>
+		{/if}
+
+	</div>
+</div><!-- .page -->
+
+{include file="frontend/components/footer.tpl"}


### PR DESCRIPTION
Style and size content area for journal index/homepage. 
Add smarty logic and template option to split journals into two columns: Journals and Proceedings.

![Screen Shot 2021-04-01 at 2 31 15 PM](https://user-images.githubusercontent.com/1069588/113338315-f2ea8d00-92f6-11eb-96fc-25910d15dd5c.png)
